### PR TITLE
fix tomcat jdbc warning

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=ERROR, A1
+log4j.rootLogger=WARN, A1
 
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 


### PR DESCRIPTION
SEVERE [main] org.apache.catalina.core.JreMemoryLeakPreventionListener.lifecycleEvent Failed to load class [com.mysql.cj.jdbc.NonRegisteringDriver] during Tomcat start to prevent possible memory leaks.